### PR TITLE
Fix childern to children typo

### DIFF
--- a/fixture/vcr_cassettes/post_create_page_type_database.json
+++ b/fixture/vcr_cassettes/post_create_page_type_database.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"childern\":[],\"parent\":{\"database_id\":\"ee90be7f3fd14fd5961ef4203c7d9a81\"},\"properties\":{\"title\":{\"title\":[{\"text\":{\"content\":\"Create Page Database\"},\"type\":\"text\"}]}}}",
+      "body": "{\"children\":[],\"parent\":{\"database_id\":\"ee90be7f3fd14fd5961ef4203c7d9a81\"},\"properties\":{\"title\":{\"title\":[{\"text\":{\"content\":\"Create Page Database\"},\"type\":\"text\"}]}}}",
       "headers": {
         "Notion-Version": "2021-05-13",
         "Authorization": "***",

--- a/fixture/vcr_cassettes/post_create_page_type_page.json
+++ b/fixture/vcr_cassettes/post_create_page_type_page.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"childern\":[],\"parent\":{\"page_id\":\"9b4a624d5a18482ab2187e54166edda7\"},\"properties\":{}}",
+      "body": "{\"children\":[],\"parent\":{\"page_id\":\"9b4a624d5a18482ab2187e54166edda7\"},\"properties\":{}}",
       "headers": {
         "Notion-Version": "2021-05-13",
         "Authorization": "***",

--- a/fixture/vcr_cassettes/post_create_page_type_page_error_parent_id.json
+++ b/fixture/vcr_cassettes/post_create_page_type_page_error_parent_id.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"childern\":[],\"parent\":{\"database_id\":\"9b4a624d5a18482ab2187e54166edda7\"},\"properties\":{\"title\":{\"title\":[{\"text\":{\"content\":\"Create Page Database\"},\"type\":\"text\"}]}}}",
+      "body": "{\"children\":[],\"parent\":{\"database_id\":\"9b4a624d5a18482ab2187e54166edda7\"},\"properties\":{\"title\":{\"title\":[{\"text\":{\"content\":\"Create Page Database\"},\"type\":\"text\"}]}}}",
       "headers": {
         "Notion-Version": "2021-05-13",
         "Authorization": "***",

--- a/lib/thin_notion_api/pages.ex
+++ b/lib/thin_notion_api/pages.ex
@@ -41,7 +41,7 @@ defmodule ThinNotionApi.Pages do
     body_params = %{}
     |> Properties.set_page_parent(parent_id)
     |> Map.put(:properties, properties)
-    |> Map.put(:childern, children)
+    |> Map.put(:children, children)
 
     post("pages", body_params)
   end
@@ -50,7 +50,7 @@ defmodule ThinNotionApi.Pages do
     body_params = %{}
     |> Properties.set_database_parent(parent_id)
     |> Properties.set_database_properties(properties)
-    |> Map.put(:childern, children)
+    |> Map.put(:children, children)
 
     post("pages", body_params)
   end


### PR DESCRIPTION
Notion is throwing a variety of 400 errors when passing a JSON with a childern key to the API, fixing the typo solves the problem.