### PR TITLE
Migrate from mix config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
-config :thin_notion_api, :api_key, "test_api_key"
-config :thin_notion_api, :notion_version, "2021-08-16"
+config :thin_notion_api, :api_key, System.get_env("NOTION_API_KEY", "test_api_key")
+config :thin_notion_api, :notion_version, System.get_env("NOTION_VERSION", "2021-08-16")
 
 config :exvcr,
   vcr_cassette_library_dir: "fixture/vcr_cassettes",

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
-use Mix.Config
+import Config
 
-config :thin_notion_api, :api_key, System.get_env("NOTION_API_KEY")
-config :thin_notion_api, :notion_version, System.get_env("NOTION_VERSION")
+config :thin_notion_api, :api_key, "test_api_key"
+config :thin_notion_api, :notion_version, "2021-08-16"
 
-config :exvcr, [
+config :exvcr,
   vcr_cassette_library_dir: "fixture/vcr_cassettes",
   custom_cassette_library_dir: "fixture/custom_cassettes",
   filter_sensitive_data: [
@@ -12,4 +12,3 @@ config :exvcr, [
   filter_url_params: false,
   filter_request_headers: ["Authorization"],
   response_headers_blacklist: []
-]

--- a/lib/thin_notion_api/utils.ex
+++ b/lib/thin_notion_api/utils.ex
@@ -3,18 +3,14 @@ defmodule ThinNotionApi.Utils do
 
   def api_key, do: Application.get_env(:thin_notion_api, :api_key)
 
-  def notion_version,
-    do: Application.get_env(:thin_notion_api, :notion_version, "2021-08-16")
+  def notion_version, do: Application.get_env(:thin_notion_api, :notion_version)
 
   def auth_header do
-    key = if Mix.env() == :test do
-      api_key() || "test_api_key"
-    else
-      api_key()
-    end
+    key = api_key()
 
     [{"Authorization", "Bearer " <> key}]
   end
+
   def version_header, do: [{"Notion-Version", notion_version()}]
   def content_header, do: [{"Content-Type", "application/json"}]
   def request_headers, do: version_header() ++ auth_header()


### PR DESCRIPTION
Passing defaults in the config.exs was the easiest way to remove the Mix.env from the utils.